### PR TITLE
Fix run errors

### DIFF
--- a/mask_rcnn_2go/run.sh
+++ b/mask_rcnn_2go/run.sh
@@ -42,6 +42,7 @@ echo "
   \"--remote_repository\": \"origin\",
   \"--repo\": \"git\",
   \"--repo_dir\": \"${REPO_DIR}\",
+  \"--root_model_dir\": \"${CONFIG_DIR}/root_model_dir\",
   \"--screen_reporter\": null
 }
 " > ${CONFIG_DIR}/config.txt


### PR DESCRIPTION
run_bench.py: error: the following arguments are required: --root_model_dir

See: https://github.com/facebook/FAI-PEP/issues/284